### PR TITLE
disable restricted mode (strict)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
+    "strict": false,   //disable restricted mode (strict) / desabilitar modo restrito / Para evitar erros de compilação por causa do modo restrito
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,


### PR DESCRIPTION
To avoid compilation errors because of strict mode.
Para evitar erros de compilação por causa do modo restrito, o recomendado é desabilitá-lo no projeto.
